### PR TITLE
fix args.moe_enabled check in utils.py

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -354,9 +354,10 @@ def get_params():
     assert (
         args.world_size % (args.tp_num * args.pp_num) == 0
     ), f"world size: {args.world_size}, tp: {args.tp_num}, pp: {args.pp_num}"
-    assert (
-        args.moe_enabled and args.enable_sequence_parallel
-    ), f"moe must be enabled with sequence parallel"
+    if args.moe_enabled:
+        assert (
+            args.moe_enabled and args.enable_sequence_parallel
+        ), f"moe must be enabled with sequence parallel"
     args.dp_num = args.world_size // (args.tp_num * args.pp_num)
     # assert args.global_batch % (args.dp_num * args.micro_batch) == 0, \
     #     f"global_batch: {args.global_batch}, dp: {args.dp_num}, micro_batch: {args.micro_batch}"


### PR DESCRIPTION
issue #1 
Only if '-m moe' in scripts, check assrt"args.moe_enabled and args.enable_sequence_parallel “

              > Hi, I also met the same problem. Is there any working example that I can test SimAI? Thanks!

it seems like some bug in utils.py
I think it will be helpful to edit the code here
https://github.com/aliyun/aicb/blob/cd91399267252cd8cd18bb185c1980606bf0c014/utils/utils.py#L357-L359

add a line
 if args.moe_enabled :
```python
if args.moe_enabled :
   assert ( 
       args.moe_enabled and args.enable_sequence_parallel 
   ), f"moe must be enabled with sequence parallel" 
```

_Originally posted by @1195343015 in https://github.com/aliyun/aicb/issues/1#issuecomment-2277330805_
            