### PR TITLE
Fix issue 22 incorrect filling computation time into the msg_size

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -246,7 +246,7 @@ def Comp_with_aiob(workload, compute_cache):
             for key in compute_cache:
                 key_temp = key.split("_")[0]
                 if key_temp in item.stage:
-                    item.msg_size = compute_cache[key]
+                    item._elapsed_time = compute_cache[key]
                     break
     return workload
 

--- a/workload_applyer.py
+++ b/workload_applyer.py
@@ -357,7 +357,7 @@ class WorkloadApplyer:
         if self.skip_computation:
             return
         if self.computation_aiob:
-            time.sleep(item.msg_size / 1e9)
+            time.sleep(item._elapsed_time / 1e9)
         else:
             # item.msg_size = 1
             input_shape1, input_shape2 = item.msg_size


### PR DESCRIPTION
Fixed the issue of msg_size being overwritten by _ elapsed_time in the generated workload code