### PR TITLE
Fix the entire attention's _elapsed_time is repeatedly assigned to attention_comlumn and attention_row

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -246,7 +246,7 @@ def Comp_with_aiob(workload, compute_cache):
             for key in compute_cache:
                 key_temp = key.split("_")[0]
                 if key_temp in item.stage:
-                    item.msg_size = compute_cache[key]
+                    item._elapsed_time = compute_cache[key]
                     break
     return workload
 

--- a/workload_applyer.py
+++ b/workload_applyer.py
@@ -357,7 +357,7 @@ class WorkloadApplyer:
         if self.skip_computation:
             return
         if self.computation_aiob:
-            time.sleep(item.msg_size / 1e9)
+            time.sleep(item._elapsed_time / 1e9)
         else:
             # item.msg_size = 1
             input_shape1, input_shape2 = item.msg_size

--- a/workload_generator/mocked_model/MockedMegatron.py
+++ b/workload_generator/mocked_model/MockedMegatron.py
@@ -109,7 +109,7 @@ class MegatronRowLinear(MockedModel):
                         (self.seq_len, self.batch_size, self.output_size),
                         self.weight.shape,
                     ),
-                    stage="backward.MegatronRowLinear" + self.name,
+                    stage="backward.MegatronRowLinear." + self.name,
                 )
             )
             workloads.append(
@@ -119,7 +119,7 @@ class MegatronRowLinear(MockedModel):
                         (self.output_size, self.seq_len * self.batch_size),
                         (self.seq_len * self.batch_size, self.input_size_per_partition),
                     ),
-                    stage="backward.MegatronRowLinear" + self.name,
+                    stage="backward.MegatronRowLinear." + self.name,
                 )
             )
         return workloads


### PR DESCRIPTION
Fix issue https://github.com/aliyun/aicb/issues/26#issue-2760460540
Perform separate statistics on the two parts of attention or mlp in compute_cache, and fixed the spelling error of item.stage in mlp_row which missing a **.**, this will result in less trainning time prediction.