### PR TITLE
add better doc for Mocked Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ sh scripts/megatron_gpt.sh \
 ## Generate Workloads for Simulation (SimAI)
 In addition to running the AICB in the GPU clusters, AICB also generates the workload description files which can be used for simulation or further analysis.
 In this release, we provide [scripts](scripts/megatron_workload_with_aiob.sh) for quickly generating workloads for SimAI.
+For now MLA and Linear Attention Models are not supported. To customize your own workloads, please refer to [Customized parameters](workload_generator/mocked_model/MockedModel.py) and add new models.
 
 ### Generating the workload description files for the whole benchmark suite
 You can generate all the workload description files with [generate_suite]() as specified in our AICB workload spec v1.0. Once these files are created, you can execute them using the SimAI to test and analyze various scenarios.

--- a/workload_generator/mocked_model/AiobMegatron.py
+++ b/workload_generator/mocked_model/AiobMegatron.py
@@ -59,23 +59,6 @@ class MegatronModel(torch.nn.Module):
         self.grad_param = Grad_param(self.args)
 
     def forward(self, input):
-        # if self.args.warm_up:
-        #     for _ in range(10):
-
-        #         layernorm = self.Layernorm._apply()
-        #         atten_qkv = self.Attention._apply_attenqkv()
-        #         if self.args.use_flash_attn :
-        #             atten_core = self.Attention._apply_flash_atten()
-        #         else:
-        #             atten_core_qk = self.Attention._apply_QK()
-        #             atten_core_softmax = self.Attention._apply_Softmax()
-        #             atten_core_contex = self.Attention._apply_Contex()
-        #         atten_linear = self.Attention._apply_Linear()
-        #         layernorm2 = self.Layernorm._apply()
-        #         mlp_linear_1 = self.Mlp._apply_Linear1()
-        #         mlp_gelu = self.Mlp._apply_activation()
-        #         mlp_linear_2 = self.Mlp._apply_Linear2()
-
         for _ in range(self.args.epoch_num):
             # #Embedding
             Emb_output, Emb_time = self.Embedding(input)
@@ -304,13 +287,6 @@ class MegatronEmbedding(torch.nn.Module):
 
     @cuda_timing_decorator
     def _apply(self, input):
-        # words_embeddings = F.embedding(self.masked_input,
-        #                                self.weight,
-        #                                 None, None,
-        #                                 2.0, False,
-        #                                 False)
-        # input_ = input
-
         if self.tp > 1:
             # Build the mask.
             input_mask = (input < 0) | (input >= math.ceil(self.vocab_size / self.tp))


### PR DESCRIPTION
People might use different models other than QWen. For example, Linear Attention and MLA might be used. These models are not supported in AICB, but we can modify the script to support these models. These modification mentions which file to change