### PR TITLE
Add DeepSeek-v3 workload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN mv ./workload_generator /usr/local/lib/python3.10/dist-packages &&\
     mv ./utils /usr/local/lib/python3.10/dist-packages &&\
     mv ./log_analyzer /usr/local/lib/python3.10/dist-packages &&\
     pip install git+https://github.com/fanshiqing/grouped_gemm@v1.0 &&\
-    pip3 install einops 
-
+    pip3 install einops  && \
+    echo 'install deep_gemm for DeepSeek AIOB' && \
+    pip3 install git+https://github.com/deepseek-ai/DeepGEMM@391755ada0ffefa9a6a52b6f14dcaf22d1a463e0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM nvcr.io/nvidia/pytorch:23.08-py3
 
 WORKDIR /workspace/AICB
 
-Copy . /workspace/AICB
+COPY . /workspace/AICB
 
 RUN mv ./workload_generator /usr/local/lib/python3.10/dist-packages &&\
     mv ./utils /usr/local/lib/python3.10/dist-packages &&\
     mv ./log_analyzer /usr/local/lib/python3.10/dist-packages &&\
-    pip install git+https://github.com/fanshiqing/grouped_gemm@v1.0 \
+    pip install git+https://github.com/fanshiqing/grouped_gemm@v1.0 &&\
     pip3 install einops 
 
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ Bug Fixes
     - [Running workloads for Megatron](#running-workloads-for-megatron)
     - [Running workloads for MOE](#running-workloads-for-moe)
     - [Running workloads for DeepSpeed](#running-workloads-for-deepspeed)
+    - [Running workloads for DeepSeek](#running-workloads-for-deepseek)
     - [Embedding the compuation patterns in the workload](#embedding-the-compuation-patterns-in-the-workload)
   - [Generate Workloads for Simulation (SimAI)](#generate-workloads-for-simulation-simai)
     - [Generating the workload description files for the whole benchmark suite](#generating-the-workload-description-files-for-the-whole-benchmark-suite)
     - [Generating the workload description files for Megatron](#generating-the-workload-description-files-for-megatron)
     - [Generating the workload description files for Moe](#generating-the-workload-description-files-for-moe)
+    - [Generating the workload description files for DeepSeek](#generating-the-workload-description-files-for-deepseek)
     - [Generating the workload description files for DeepSpeed](#generating-the-workload-description-files-for-deepspeed)
   - [Running AICB with customized parameters](#running-aicb-with-customized-parameters)
     - [Running customized workloads on physical GPU clusters](#running-customized-workloads-on-physical-gpu-clusters)
@@ -165,6 +167,25 @@ sh scripts/deepspeed_llama.sh \
 --reduce_bucket_size=1000000000 --allgather_bucket_size=500000000 \
 --param_persistence_threshold=1000000 \
 ```
+
+### Running workloads for DeepSeek
+
+For `DeepSeek`, one can use the [scripts/megatron_gpt.sh](./scripts/megatron_gpt.sh) with `--frame=DeepSeek`
+
+```bash
+sh scripts/megatron_gpt.sh \
+  --frame DeepSeek \
+  --tensor_model_parallel_size 4 \
+  --pipeline_model_parallel 1 \
+  --moe_enable \
+  --expert_model_parallel_size 1 \
+  --global_batch 4 \
+  -m deepseek \
+  --num_experts 4 \
+  --micro_batch 1 \
+  --sp --swiglu --world_size 4 --num_layers 10 --aiob_enable
+```
+
 ### Embedding the compuation patterns in the workload
 To mirror the real-world workloads with both computation and communicaiton, we developed a sub-module, AIOB, that is used to generate computation patterns.
 In AICB, we can enable AIOB to embed the computation time into the workloads.
@@ -196,7 +217,7 @@ sh scripts/megatron_gpt.sh \
 ## Generate Workloads for Simulation (SimAI)
 In addition to running the AICB in the GPU clusters, AICB also generates the workload description files which can be used for simulation or further analysis.
 In this release, we provide [scripts](scripts/megatron_workload_with_aiob.sh) for quickly generating workloads for SimAI.
-For now MLA and Linear Attention Models are not supported. To customize your own workloads, please refer to [Customized parameters](workload_generator/mocked_model/MockedModel.py) and add new models.
+For now Linear Attention Models are not supported. To customize your own workloads, please refer to [Customized parameters](workload_generator/mocked_model/MockedModel.py) and add new models.
 
 ### Generating the workload description files for the whole benchmark suite
 You can generate all the workload description files with [generate_suite]() as specified in our AICB workload spec v1.0. Once these files are created, you can execute them using the SimAI to test and analyze various scenarios.
@@ -231,6 +252,19 @@ sh scripts/megatron_workload_with_aiob.sh \
 --frame Megatron --global_batch 1024  \
 --micro_batch 1 --seq_length 4096 --swiglu \
 --use_flash_attn  --aiob_enable 
+```
+
+### Generating the workload description files for DeepSeek
+
+For the DeepSeek, you can also use [scripts/megatron_workload_with_aiob.sh](scripts/megatron_workload_with_aiob.sh)
+
+```bash
+sh scripts/megatron_workload_with_aiob.sh \
+-m deepseek16 --world_size 2048 --tensor_model_parallel_size 1 --pipeline_model_parallel 1 --sp --ep 16 \
+--moe_router_topk 6 --moe_enable  \
+--frame DeepSeek --global_batch 4096 \
+--micro_batch 1 --seq_length 4096 --swiglu \
+--aiob_enable
 ```
 
 ### Generating the workload description files for DeepSpeed

--- a/aicb.py
+++ b/aicb.py
@@ -14,6 +14,7 @@ import torch
 from utils.utils import get_args, get_comp_out, extract_averages, Comp_with_aiob
 from utils.benchmark_logger import bench_logger
 from workload_generator.mocked_model.MockedDeepspeed import DeepspeedForCausalLM
+from workload_generator.mocked_model.MockedDeepSeek import DeepSeekV3Model
 from workload_generator.mocked_model.MockedMegatron import MegatronModel
 from workload_generator.generate_deepspeed_stage1_2_workload import (
     DeepSpeedStage1,
@@ -45,8 +46,11 @@ if __name__ == "__main__":
             workload_generator = DeepSpeedStage3(args, model)
     elif args.frame == "collective_test":
         workload_generator = Collective_Test(args, None)
+    elif args.frame == "DeepSeek":
+        model = DeepSeekV3Model(args)
+        workload_generator = MegatronWorkload(args, model)
     workload = workload_generator()
-    if args.aiob_enable and args.frame == "Megatron":
+    if args.aiob_enable and (args.frame == "Megatron" or args.frame == "DeepSeek"):
         
         params = model.parameters()
         args.model_param = sum(p.numel() for p in params)

--- a/scripts/megatron_gpt.sh
+++ b/scripts/megatron_gpt.sh
@@ -190,6 +190,67 @@ case $model_size in
     moe_enable=--moe_enable
     grouped_gemm=--moe_grouped_gemm
     ;;
+  deepseek671)
+    model_name=DeepSeek_671B
+    frame=DeepSeek
+    moe_enable=--moe_enable
+    num_layers=61
+    hidden_size=18432
+    num_attention_heads=128
+    ffn_hidden_size=2048
+    q_lora_rank=1536
+    kv_lora_rank=512
+    qk_nope_dim=128
+    qk_rope_dim=64
+    v_head_dim=128
+    num_experts=256
+    n_shared_expert=1
+    n_dense_layer=3
+    tensor_model_parallel_size=1
+    ;;
+  deepseek236)
+    model_name=DeepSeek_236B
+    frame=DeepSeek
+    moe_enable=--moe_enable
+    num_layers=60
+    hidden_size=12288
+    num_attention_heads=128
+    ffn_hidden_size=1536
+    q_lora_rank=1536
+    kv_lora_rank=512
+    qk_nope_dim=128
+    qk_rope_dim=64
+    v_head_dim=128
+    num_experts=160
+    n_shared_expert=2
+    n_dense_layer=1
+    tensor_model_parallel_size=1
+    ;;
+  deepseek16)
+    model_name=DeepSeek_16B
+    frame=DeepSeek
+    moe_enable=--moe_enable
+    num_layers=27
+    hidden_size=10944
+    num_attention_heads=16
+    ffn_hidden_size=1408
+    q_lora_rank=0
+    kv_lora_rank=512
+    qk_nope_dim=128
+    qk_rope_dim=64
+    v_head_dim=128
+    num_experts=64
+    n_shared_expert=2
+    n_dense_layer=1
+    tensor_model_parallel_size=1
+    ;;
+  deepseek)
+    frame=DeepSeek
+    model_name="DeepSeek"
+    moe_enable=--moe_enable
+    ;;
+    # set everything else from cmdline
+    # or it defaults to utils/utils.py's arg parser
   (*)
     echo "Only support model size 405,175,22,13,7 or moe; using default size 13"
     model_name=gpt_13B
@@ -235,7 +296,15 @@ cmd="$script \
   ${moe_router_topk:+--moe_router_topk=$moe_router_topk} \
   ${num_experts:+--num_experts=$num_experts} \
   ${expert_model_parallel_size:+--expert_model_parallel_size=$expert_model_parallel_size} \
-  ${grouped_gemm}"
+  ${grouped_gemm} \
+  ${q_lora_rank:+--q_lora_rank=$q_lora_rank} \
+  ${kv_lora_rank:+--kv_lora_rank=$kv_lora_rank} \
+  ${qk_nope_dim:+--qk_nope_dim=$qk_nope_dim} \
+  ${qk_rope_dim:+--qk_rope_dim=$qk_rope_dim} \
+  ${v_head_dim:+--v_head_dim=$v_head_dim} \
+  ${n_shared_expert:+--n_shared_expert=$n_shared_expert} \
+  ${n_dense_layer:+--n_dense_layer=$n_dense_layer} \
+  "
 echo $cmd
 
 if [ $workload_only ]; then

--- a/scripts/megatron_workload_with_aiob.sh
+++ b/scripts/megatron_workload_with_aiob.sh
@@ -46,7 +46,7 @@ usage() {
       --ffn_hidden_size         FFN hidden size
       --comp_filepath           computation file path
       --max_position_embeddings max position embeddings, defaults to $max_position_embeddings
-      -m, --model_size          model size, defaults to $model_size (possible values: 175, 22, 13, 7, moe)
+      -m, --model_size          model size, defaults to $model_size (possible values: 175, 22, 13, 7, moe, deepseek671, deepseek236, deepseek16)
       --moe_enable             enable moe
       --moe_router_topk         Number of experts to route to for each token.
       --expert_model_parallel_size     Degree of expert model parallelism
@@ -166,6 +166,67 @@ case $model_size in
     moe_enable=--moe_enable
     grouped_gemm=--moe_grouped_gemm
     ;;
+  deepseek671)
+    model_name=DeepSeek_671B
+    frame=DeepSeek
+    moe_enable=--moe_enable
+    num_layers=61
+    hidden_size=18432
+    num_attention_heads=128
+    ffn_hidden_size=2048
+    q_lora_rank=1536
+    kv_lora_rank=512
+    qk_nope_dim=128
+    qk_rope_dim=64
+    v_head_dim=128
+    num_experts=256
+    n_shared_expert=1
+    n_dense_layer=3
+    tensor_model_parallel_size=1
+    ;;
+  deepseek236)
+    model_name=DeepSeek_236B
+    frame=DeepSeek
+    moe_enable=--moe_enable
+    num_layers=60
+    hidden_size=12288
+    num_attention_heads=128
+    ffn_hidden_size=1536
+    q_lora_rank=1536
+    kv_lora_rank=512
+    qk_nope_dim=128
+    qk_rope_dim=64
+    v_head_dim=128
+    num_experts=160
+    n_shared_expert=2
+    n_dense_layer=1
+    tensor_model_parallel_size=1
+    ;;
+  deepseek16)
+    model_name=DeepSeek_16B
+    frame=DeepSeek
+    moe_enable=--moe_enable
+    num_layers=27
+    hidden_size=10944
+    num_attention_heads=16
+    ffn_hidden_size=1408
+    q_lora_rank=0
+    kv_lora_rank=512
+    qk_nope_dim=128
+    qk_rope_dim=64
+    v_head_dim=128
+    num_experts=64
+    n_shared_expert=2
+    n_dense_layer=1
+    tensor_model_parallel_size=1
+    ;;
+  deepseek)
+    frame=DeepSeek
+    model_name="DeepSeek"
+    moe_enable=--moe_enable
+    ;;
+    # set everything else from cmdline
+    # or it defaults to utils/utils.py's arg parser
   (*)
     echo "Only support model size 175, 22,13 or 7; using default size 13"
     model_name=gpt_13B
@@ -204,7 +265,15 @@ cmd="python -m workload_generator.AIOB_simAI_workload_generator \
   ${moe_router_topk:+--moe_router_topk=$moe_router_topk} \
   ${num_experts:+--num_experts=$num_experts} \
   ${expert_model_parallel_size:+--expert_model_parallel_size=$expert_model_parallel_size} \
-  ${grouped_gemm} " \
+  ${grouped_gemm} \
+  ${q_lora_rank:+--q_lora_rank=$q_lora_rank} \
+  ${kv_lora_rank:+--kv_lora_rank=$kv_lora_rank} \
+  ${qk_nope_dim:+--qk_nope_dim=$qk_nope_dim} \
+  ${qk_rope_dim:+--qk_rope_dim=$qk_rope_dim} \
+  ${v_head_dim:+--v_head_dim=$v_head_dim} \
+  ${n_shared_expert:+--n_shared_expert=$n_shared_expert} \
+  ${n_dense_layer:+--n_dense_layer=$n_dense_layer} \
+  " \
 
 echo $cmd
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -257,10 +257,9 @@ def get_comp_out(args):
     seq_len = args.seq_length
     tp = args.tensor_model_parallel_size
     vocab_size = args.padded_vocab_size
-    if "Megatron" in args.frame:
+    if "Megatron" or "DeepSeek" in args.frame:
         device = torch.cuda.current_device()
         from workload_generator.mocked_model.AiobMegatron import MegatronModel
-
         measure_model = MegatronModel(args)
         measure_model.train()
         if args.dtype == "bfloat16":

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -500,7 +500,7 @@ def get_params():
     parser.add_argument(
         "--frame",
         help="communication framework",
-        choices=["Megatron", "DeepSpeed", "collective_test"],
+        choices=["Megatron", "DeepSpeed", "collective_test", "DeepSeek"],
         default="Megatron",
     )
     parser.add_argument("--gpu_type", type=str, default=None),
@@ -550,6 +550,7 @@ def get_params():
     get_moe_params(parser)
     get_simAI_workload_params(parser)
     get_aiob_params(parser)
+    get_deepseek_params(parser)
     args = parser.parse_args()
 
     assert (
@@ -715,6 +716,38 @@ def get_moe_params(parser: argparse.ArgumentParser):
     parser.add_argument('--moe_grouped_gemm', action='store_true',
                        help='When there are multiple experts per rank, compress multiple local (potentially small) gemms in a single kernel launch to improve the utilization and performance by leveraging the Grouped GEMM feature introduced since CUTLASS 2.8 (https://github.com/fanshiqing/grouped_gemm).')
     parser.add_argument('--activation_func', type=str,help='activation_func for mlp')
+
+def get_deepseek_params(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--n_dense_layers", type=int, default=3, help="Number of dense (non-MoE) layers"
+    )
+    parser.add_argument(
+        "--n_shared_expert",
+        type=int,
+        default=2,
+        help="Number of shared experts for DeepSeek model",
+    )
+    parser.add_argument(
+        "--qk_rope_dim",
+        type=int,
+        default=64,
+        help="Dimention of QK with positional embeddings",
+    )
+    parser.add_argument(
+        "--qk_nope_dim",
+        type=int,
+        default=128,
+        help="Dimention of QK without positional embeddings",
+    )
+    parser.add_argument(
+        "--q_lora_rank", type=int, default=1536, help="Q down projection size"
+    )
+    parser.add_argument(
+        "--kv_lora_rank", type=int, default=512, help="KV down projection size"
+    )
+    parser.add_argument(
+        "--v_head_dim", type=int, default=128, help="Dimention for value projection"
+    )
 
 def ensure_divisibility(numerator, denominator):
     """Ensure that numerator is divisible by the denominator."""

--- a/workload_applyer.py
+++ b/workload_applyer.py
@@ -75,7 +75,7 @@ class WorkloadApplyer:
         )
         self.gemm_cache = {}
         self.computation_aiob = False
-        if args.aiob_enable and args.frame == "Megatron":
+        if args.aiob_enable and (args.frame == "Megatron" or args.frame == "DeepSeek"):
             self.computation_aiob = True
 
         self.skip_computation = False

--- a/workload_generator/generate_megatron_workload.py
+++ b/workload_generator/generate_megatron_workload.py
@@ -20,6 +20,7 @@ python -m workload_generator.megatron_workload \
 from utils.utils import CommGroup, CommType, get_params, WorkloadWriter
 from workload_generator.workload_generator import WorkloadGenerator
 from workload_generator.mocked_model.MockedMegatron import MegatronModel
+from workload_generator.mocked_model.MockedDeepSeek import DeepSeekV3Model
 from log_analyzer.log import LogItem
 
 
@@ -433,7 +434,10 @@ class MegatronWorkload(WorkloadGenerator):
 
 if __name__ == "__main__":
     args = get_params()
-    model = MegatronModel(args)
+    if args.frame == "DeepSeek":
+        model = DeepSeekV3Model(args)
+    elif args.frame == "Megatron":
+        model = MegatronModel(args)
     workload_generator = MegatronWorkload(args, model)
     workload = workload_generator()
     filename = f"{workload_generator.name}_{args.model_name}_sp_{args.enable_sequence_parallel}_iteration_{args.epoch_num}_computationEnable_{args.computation_enable}_{args.world_size}n.csv"

--- a/workload_generator/mocked_model/AiobDeepSeek.py
+++ b/workload_generator/mocked_model/AiobDeepSeek.py
@@ -1,0 +1,329 @@
+"""Provides DeepSeek implementation for Aiob compute time calculations.
+
+Based on https://github.com/deepseek-ai/DeepSeek-V3/tree/f6e34dd26772dd4a216be94a8899276c5dca9e43
+and https://github.com/deepseek-ai/DeepGEMM/tree/391755ada0ffefa9a6a52b6f14dcaf22d1a463e0
+
+Note: DeepGEMM sadly only works with SM90, SM100 i.e. Hopper and Blackwell
+
+Todo:
+- add FlashMLA from https://github.com/deepseek-ai/FlashMLA/ for attentions
+    as of https://github.com/deepseek-ai/FlashMLA/commit/41b611f7d7561790a2f5040ff89212e08c7b0011 
+    FlashMLA's kernel supports backwards :)
+- add DeepEP from https://github.com/deepseek-ai/DeepEP/
+
+@misc{deepseekai2024deepseekv3technicalreport,
+      title={DeepSeek-V3 Technical Report},
+      author={DeepSeek-AI},
+      year={2024},
+      eprint={2412.19437},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2412.19437},
+}
+
+
+File: AiobDeepSeek.py
+License: Apache 2.0
+
+"""
+
+import random
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from utils.utils import cuda_timing_decorator
+
+# needs deep_gemm from https://github.com/deepseek-ai/DeepGEMM
+try:
+    import deep_gemm
+    from deep_gemm import ceil_div
+except ImportError as e:
+    print("""
+        Needs deep_gemm from https://github.com/deepseek-ai/DeepGEMM
+        to install,
+           git clone --recursive git@github.com:deepseek-ai/DeepGEMM.git
+           cd DeepGEMM
+           ./install.sh
+    """)
+    raise e
+
+
+# from deepgemm/tests
+def per_token_cast_to_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    pad_size = (128 - (n % 128)) % 128
+    x = torch.nn.functional.pad(x, (0, pad_size), value=0) if pad_size > 0 else x
+    x_view = x.view(m, -1, 128)
+    x_amax = x_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
+    fp8_data = (x_view * (448.0 / x_amax.unsqueeze(2))).to(torch.float8_e4m3fn)
+    return fp8_data.view(m, n + pad_size)[:, :n], (x_amax / 448.0).view(m, -1)
+
+
+def per_block_cast_to_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    x_padded = torch.zeros(
+        (ceil_div(m, 128) * 128, ceil_div(n, 128) * 128), dtype=x.dtype, device=x.device,
+    )
+    x_padded[:m, :n] = x
+    x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
+    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
+    x_scaled = (x_view * (448.0 / x_amax)).to(torch.float8_e4m3fn)
+    return x_scaled.view_as(x_padded)[:m, :n].contiguous(), (x_amax / 448.0).view(
+        x_view.size(0), x_view.size(2),
+    )
+
+
+@dataclass
+class Args:
+    hidden_size: int
+    ffn_hidden_size: int
+    micro_batch: int
+    expert_model_parallel_size: int
+    num_experts: int
+    moe_router_topk: int
+    seq_length: int
+    n_shared_expert: int
+
+
+class DeepSeekExpert(torch.nn.Module):
+    """DeepSeekExpert"""
+
+    def __init__(self, args: Args):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.ffn_hidden_size = args.ffn_hidden_size
+        self.dev = torch.cuda.current_device()
+        self.w1 = torch.randn(
+            args.ffn_hidden_size,
+            args.hidden_size,
+            device=self.dev,
+        ).to(torch.bfloat16)
+        self.w1_fp8 = per_block_cast_to_fp8(self.w1)
+
+        self.w2 = torch.randn(
+            args.hidden_size,
+            args.ffn_hidden_size,
+            device=self.dev,
+        ).to(torch.bfloat16)
+
+        self.w2_fp8 = per_block_cast_to_fp8(self.w2)
+
+        self.w3 = torch.randn(
+            args.ffn_hidden_size,
+            args.hidden_size,
+            device=self.dev,
+        ).to(torch.bfloat16)
+
+        self.w3_fp8 = per_block_cast_to_fp8(self.w3)
+
+        self.o0 = torch.empty(
+            (args.seq_length, self.ffn_hidden_size),
+            device=self.dev,
+            dtype=torch.bfloat16,
+        )
+        self.o1 = torch.empty(
+            (args.seq_length, self.ffn_hidden_size),
+            device=self.dev,
+            dtype=torch.bfloat16,
+        )
+        self.out = torch.empty(
+            (args.seq_length, self.hidden_size), device=self.dev, dtype=torch.bfloat16,
+        )
+
+    @cuda_timing_decorator
+    def _apply_linear1(self, x: torch.Tensor, x_scale: torch.Tensor):
+        deep_gemm.gemm_fp8_fp8_bf16_nt((x, x_scale), self.w1_fp8, self.o0)
+        deep_gemm.gemm_fp8_fp8_bf16_nt((x, x_scale), self.w3_fp8, self.o1)
+        return (self.o0, self.o1)
+
+    @cuda_timing_decorator
+    def _apply_linear2(self, x: torch.Tensor):
+        self.out = torch.matmul(x, self.w2.T)
+        # or one can scale it down to fp8 and apply deepgemm
+        # x_fp8 = per_token_cast_to_fp8(x)
+        # deep_gemm.gemm_fp8_fp8_bf16_nt(x_fp8, self.w2_fp8, self.out)
+        return self.out
+
+    @cuda_timing_decorator
+    def _apply_activation(self, x: torch.Tensor):
+        return F.silu(x)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, float, float, float]:
+        # based on https://github.com/deepseek-ai/DeepSeek-V3/blob/f6e34dd26772dd4a216be94a8899276c5dca9e43/inference/model.py#L630
+        # i.e. out = self.w2(F.silu(self.w1(x)) * self.w3(x))
+        x, x_scale = per_token_cast_to_fp8(x.view(-1, self.hidden_size))
+        l1_out, l1_time = self._apply_linear1(x, x_scale)
+        act_out, act_time = self._apply_activation(l1_out[0])
+        l2_out, l2_time = self._apply_linear2(act_out * l1_out[0])
+        return l2_out, l1_time, act_time, l2_time
+
+
+class DeepSeekMoE(torch.nn.Module):
+    """DeepSeekMoE"""
+
+    def __init__(self, args: Args):
+        super().__init__()
+        self.n_local_experts = args.n_shared_expert + args.num_experts // args.expert_model_parallel_size
+        self.hidden_size = args.hidden_size
+        self.dev = torch.cuda.current_device()
+        in_dim = self.hidden_size * args.micro_batch
+        self.in_dim = in_dim
+        self.inter_dim = args.ffn_hidden_size * self.n_local_experts
+        # yoinked from AiobMegatron.py->MoELayer
+        ep = args.expert_model_parallel_size
+        num_experts = args.num_experts
+        micro_batch = args.micro_batch
+        seq_len = args.seq_length
+        topk = args.moe_router_topk
+        self.topk = topk
+        hidden_size = args.hidden_size
+        self.dispatched_input = torch.rand(
+            int(seq_len * micro_batch * topk * ep / num_experts * self.n_local_experts),
+            hidden_size,
+            device=self.dev,
+        ).to(torch.bfloat16)
+        self.dispatched_input_fp8 = per_token_cast_to_fp8(self.dispatched_input)
+
+        self.tokens_per_expert = torch.full(
+            (self.n_local_experts,),
+            int(seq_len * micro_batch * topk * ep / num_experts),
+        )
+
+        self.local_experts = torch.nn.ModuleList()
+        for _ in range(self.n_local_experts):
+            self.local_experts.append(DeepSeekExpert(args))
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, int,int,int]:
+        mlp_l1_all, mlp_act_all, mlp_l2_all = 0, 0, 0
+        o = torch.zeros(
+            self.n_local_experts, x.shape[0], self.hidden_size, device=self.dev,
+        ).to(torch.bfloat16)
+        for i, expert in enumerate(self.local_experts):
+            out, mlp_l1, mlp_act, mlp_l2 = expert(x.view(-1, self.in_dim))
+            mlp_l1_all += mlp_l1
+            mlp_act_all += mlp_act
+            mlp_l2_all += mlp_l2
+            o[i] = out
+        return o, mlp_l1_all, mlp_act_all, mlp_l2_all
+
+
+# some util tests to measure timings
+def test_deepseek_expert() -> torch.Tensor:
+    x = torch.randn(2048, 1, 1024, dtype=torch.bfloat16)
+    args = Args(
+        expert_model_parallel_size=1,
+        ffn_hidden_size=4096,
+        hidden_size=1024,
+        num_experts=8,
+        micro_batch=1,
+        moe_router_topk=4,
+        n_shared_expert=2,
+        seq_length=2048,
+    )
+    model = DeepSeekExpert(args)
+    y = model(x)
+    print(y)
+
+
+def test_deepseek_mlp():
+    x = torch.randn(2048, 1, 1024, dtype=torch.bfloat16)
+    args = Args(
+        expert_model_parallel_size=1,
+        ffn_hidden_size=4096,
+        hidden_size=1024,
+        num_experts=8,
+        micro_batch=1,
+        moe_router_topk=4,
+        n_shared_expert=2,
+        seq_length=2048,
+    )
+    model = DeepSeekMoE(args)
+    y = model(x)
+    return y
+
+
+def test_expert(
+    m: int = 2048 * 32, n: int = 1024, k: int = 2048 * 32,
+) -> tuple[int, int]:
+    """Test DeepSeek's expert MLP.
+
+    i.e. self.w2(F.silu(self.w1(x)) * self.w3(x))
+    with torch.matmul (BF16) and deep_gemm (FP8).
+    """
+    x = torch.randn(m, k).to(torch.bfloat16)
+    w = torch.randn(k, n).to(torch.bfloat16)
+    w = w.t()
+    w2 = torch.randn(k, n).to(torch.bfloat16)
+    w2 = w2.t()
+    o = torch.randn(m, n).to(torch.bfloat16)
+    o2 = torch.randn(m, n).to(torch.bfloat16)
+
+    w3 = torch.randn(n, k).to(torch.bfloat16)
+    w3_fp8 = per_block_cast_to_fp8(w3.t())
+
+    out = torch.randn(m, k).to(torch.bfloat16)
+    w_fp8 = per_block_cast_to_fp8(w)
+    w2_fp8 = per_block_cast_to_fp8(w2)
+    x_fp8 = per_token_cast_to_fp8(x)
+
+    _, t0 = do_deepgemm(x_fp8, w_fp8, w2_fp8, w3_fp8, o, o2, out)
+    _, t1 = do_matmul(x, w, w3, o, out)
+    return t0, t1
+
+
+@cuda_timing_decorator
+def do_deepgemm(
+    x: tuple[torch.Tensor, torch.Tensor],
+    w: tuple[torch.Tensor, torch.Tensor],
+    w2: tuple[torch.Tensor, torch.Tensor],
+    w3: torch.Tensor,
+    o: torch.Tensor,
+    o2: torch.Tensor,
+    out: torch.Tensor,
+) -> tuple[int,int]:
+    deep_gemm.gemm_fp8_fp8_bf16_nt(x, w, o)
+    deep_gemm.gemm_fp8_fp8_bf16_nt(x, w2, o2)
+    o2 = F.silu(o) + o2
+    o2_fp8 = per_token_cast_to_fp8(o2)
+    deep_gemm.gemm_fp8_fp8_bf16_nt(o2_fp8, w3, out)
+    return out
+
+
+@cuda_timing_decorator
+def do_matmul(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    w3: torch.Tensor,
+    o: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    torch.matmul(x, w.t(), out=o)
+    return torch.matmul(F.silu(o), w3, out=out)
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda:0")
+    torch.set_default_device(device)
+    torch.cuda.set_device(device)
+    torch.manual_seed(0)
+    random.seed(0)
+
+    # run once to load/cache kernels
+    test_deepseek_mlp()
+    test_expert()
+
+    # for kineto traces
+    import torch.profiler
+
+    with torch.profiler.profile(
+        on_trace_ready=torch.profiler.tensorboard_trace_handler("./log"),
+        record_shapes=True,
+        with_flops=True,
+    ) as prof:
+        test_deepseek_mlp()
+        t0, t1 = test_expert()
+    print(f"matmul: deepgemm: {t0} matmul: {t1} diff: {t1 - t0}")

--- a/workload_generator/mocked_model/AiobDeepSeek.py
+++ b/workload_generator/mocked_model/AiobDeepSeek.py
@@ -29,11 +29,129 @@ License: Apache 2.0
 
 import random
 from dataclasses import dataclass
+from typing import Optional
+import math
 
 import torch
 import torch.nn.functional as F
+import torch.nn as nn
 
-from utils.utils import cuda_timing_decorator
+# from  workload_generator.mocked_model.AiobMegatron import linear_with_grad_accumulation_and_async_allreduce
+# can't import because of circular imports
+# FIXME: maybe move this to utils
+
+from torch.cuda.amp import custom_bwd, custom_fwd
+class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
+    """See linear_with_grad_accumulation_and_async_allreduce"""
+
+    @staticmethod
+    @custom_fwd
+    def forward(
+        ctx,
+        input,
+        weight,
+        bias,
+        gradient_accumulation_fusion,
+        async_grad_allreduce,
+        sequence_parallel,
+        tp,
+    ):
+        ctx.save_for_backward(input, weight)  #
+        ctx.use_bias = bias is not None
+        ctx.gradient_accumulation_fusion = gradient_accumulation_fusion
+        ctx.async_grad_allreduce = async_grad_allreduce
+        ctx.sequence_parallel = sequence_parallel
+
+        if sequence_parallel:
+
+            total_input = input
+        else:
+            total_input = input
+
+        output = torch.matmul(total_input, weight.t())
+
+        if bias is not None:
+            output = output + bias
+        return output
+
+
+def linear_with_grad_accumulation_and_async_allreduce(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    gradient_accumulation_fusion: bool,
+    async_grad_allreduce: bool,
+    sequence_parallel: bool,
+    tp,
+) -> torch.Tensor:
+    """Linear layer execution with asynchronous communication and
+    gradient accumulation fusion in backprop.
+
+    This has the option to accumulate the result of backprop
+    calculation into an existing gradient buffer, preventing the need
+    to do an additional addition kernel after the gradient
+    calculation.
+
+    Additionally, the tensor parallel all reduce of the input
+    gradients can be done asynchronously with the calculation of
+    the weight gradients.
+
+    In the case of sequence parallelism, the reduce scatter of the
+    input gradients is done asynchronously with the calcluation of the
+    weight gradients.
+
+    Use of this module requires that the environment variable
+    CUDA_DEVICE_MAX_CONNECTIONS=1. There are a few collective
+    operations, noted in the code, that should be scheduled before
+    compute kernels to overlap the communication with the computation,
+    which is necessary for a speedup but not for correctness so that
+    ordering isn't imposed by the scheduler. Setting
+    CUDA_DEVICE_MAX_CONNECTIONS=1 forces the kernels to be scheduled
+    in the order they are called.
+
+    Arguments:
+
+    input (torch.Tensor required): input like torch.nn.functional.linear
+
+    weight (torch.Tensor required): weight like torch.nn.functional.linear
+
+    bias (torch.Tensor optional): bias like torch.nn.functional.linear
+
+    gradient_accumulation_fusion (bool required): Perform the gradient
+        accumulation fusion, requires the custom CUDA extension
+        fused_weight_gradient_mlp_cuda module. To use
+        gradient_accumulation_fusion you must install APEX with
+        --cpp_ext and --cuda_ext. For example: "pip install
+        --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext .\"
+        " Note that the extension requires CUDA>=11. Otherwise, you
+        must turn off gradient accumulation fusion."
+
+    async_grad_allreduce (bool required): Do the allreduce of input
+        gradients asyncronously with the computation of weight
+        gradients. If sequence_parallel is True, this must be
+        False, as no all reduce is performed.
+
+    sequence_parallel (bool required): Indicates that sequence
+        parallelism is used and thus in the forward pass the input is
+        all gathered, and the backward pass the input gradients are
+        reduce scattered.
+    """
+    args = [
+        input,
+        weight,
+        bias,
+        gradient_accumulation_fusion,
+        async_grad_allreduce,
+        sequence_parallel,
+        tp,
+    ]
+
+    return LinearWithGradAccumulationAndAsyncCommunication.apply(*args)
+
+
+linear_with_grad_accumulation_and_async_allreduce.warned = False
+
+from utils.utils import cuda_timing_decorator, divide
 
 # needs deep_gemm from https://github.com/deepseek-ai/DeepGEMM
 try:
@@ -55,7 +173,8 @@ def per_token_cast_to_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2
     m, n = x.shape
     pad_size = (128 - (n % 128)) % 128
-    x = torch.nn.functional.pad(x, (0, pad_size), value=0) if pad_size > 0 else x
+    x = torch.nn.functional.pad(
+        x, (0, pad_size), value=0) if pad_size > 0 else x
     x_view = x.view(m, -1, 128)
     x_amax = x_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
     fp8_data = (x_view * (448.0 / x_amax.unsqueeze(2))).to(torch.float8_e4m3fn)
@@ -66,14 +185,17 @@ def per_block_cast_to_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2
     m, n = x.shape
     x_padded = torch.zeros(
-        (ceil_div(m, 128) * 128, ceil_div(n, 128) * 128), dtype=x.dtype, device=x.device,
+        (ceil_div(m, 128) * 128, ceil_div(n, 128) * 128),
+        dtype=x.dtype,
+        device=x.device,
     )
     x_padded[:m, :n] = x
     x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
     x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
     x_scaled = (x_view * (448.0 / x_amax)).to(torch.float8_e4m3fn)
     return x_scaled.view_as(x_padded)[:m, :n].contiguous(), (x_amax / 448.0).view(
-        x_view.size(0), x_view.size(2),
+        x_view.size(0),
+        x_view.size(2),
     )
 
 
@@ -87,7 +209,434 @@ class Args:
     moe_router_topk: int
     seq_length: int
     n_shared_expert: int
+    qk_nope_dim: int
+    qk_rope_dim: int
+    v_head_dim: int
+    q_lora_rank: int
+    kv_lora_rank: int
+    num_attention_heads: int
+    enable_sequence_parallel: bool
+    tensor_model_parallel_size: int
 
+# from deepseek (without quantization part)
+# https://github.com/deepseek-ai/DeepSeek-V3/blob/9b4e9788e4a3a731f7567338ed15d3ec549ce03b/inference/model.py
+def linear(x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """
+    Applies a linear transformation to the incoming data: y = xA^T + b.
+
+    Args:
+        x (torch.Tensor): The input tensor.
+        weight (torch.Tensor): The weight tensor. It may be quantized and
+            requires dequantization for certain cases.
+        bias (Optional[torch.Tensor]): The bias tensor to be added. Default is None.
+    """
+    # sequence parallel, and tp are no-op in linear_with_grad_accumulation_and_async_allreduce -> LinearWithGradAccumulationAndAsyncCommunication
+    return linear_with_grad_accumulation_and_async_allreduce(input=x,
+                                                      weight=weight,
+                                                      bias=bias,
+                                                      gradient_accumulation_fusion=True,
+                                                      async_grad_allreduce=False,
+                                                      sequence_parallel=True,
+                                                      tp=1)
+
+
+class Linear(nn.Module):
+    """
+    Custom linear layer with support for quantized weights and optional bias.
+
+    Args:
+        in_features (int): Number of input features.
+        out_features (int): Number of output features.
+        bias (bool): Whether to include a bias term. Defaults to False.
+        dtype (optional): Data type for the layer. Defaults to `torch.bfloat16`.
+    """
+    dtype = torch.bfloat16
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype = None):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=dtype or Linear.dtype))
+        if self.weight.element_size() == 1:
+            pass
+            # skip scaling part
+            # scale_out_features = (out_features + block_size - 1) // block_size
+            # scale_in_features = (in_features + block_size - 1) // block_size
+            # self.weight.scale = self.scale = nn.Parameter(torch.empty(scale_out_features, scale_in_features, dtype=torch.float32))
+        else:
+            self.register_parameter("scale", None)
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the custom linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Transformed tensor after linear computation.
+        """
+        return linear(x, self.weight, self.bias)
+
+
+class ColumnParallelLinear(Linear):
+    """
+    Linear layer with column parallelism, splitting output features across distributed processes.
+
+    Args:
+        in_features (int): Number of input features.
+        out_features (int): Total number of output features.
+        bias (bool): Whether to include a bias term. Defaults to False.
+        dtype (optional): Data type for the layer. Defaults to `torch.bfloat16`.
+    """
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype = None, world_size: int = 1):
+        assert out_features % world_size == 0, f"Output features must be divisible by world size (world_size={world_size})"
+        self.part_out_features = out_features // world_size
+        super().__init__(in_features, self.part_out_features, bias, dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for column parallel linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Transformed tensor with column-parallel computation.
+        """
+        y = linear(x, self.weight, self.bias)
+        return y
+
+
+class RowParallelLinear(Linear):
+    """
+    Linear layer with row parallelism, splitting input features across distributed processes.
+
+    Args:
+        in_features (int): Total number of input features.
+        out_features (int): Number of output features.
+        bias (bool): Whether to include a bias term. Defaults to False.
+        dtype (optional): Data type for the layer. Defaults to `torch.bfloat16`.
+    """
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype = None, world_size: int = 1):
+        assert in_features % world_size == 0, f"Input features must be divisible by world size (world_size={world_size})"
+        self.part_in_features = in_features // world_size
+        super().__init__(self.part_in_features, out_features, bias, dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for row parallel linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Transformed tensor with row-parallel computation.
+        """
+        y = linear(x, self.weight)
+        # if world_size > 1:
+        #     dist.all_reduce(y)
+        if self.bias is not None:
+            y += self.bias
+        return y
+class RMSNorm(torch.nn.Module):
+    """
+    Root Mean Square Layer Normalization (RMSNorm).
+
+    Args:
+        dim (int): Dimension of the input tensor.
+        eps (float): Epsilon value for numerical stability. Defaults to 1e-6.
+    """
+    def __init__(self, dim: int, eps: float = 1e-6, dtype = torch.bfloat16):
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = torch.nn.Parameter(torch.ones(dim, dtype=dtype))
+
+    def forward(self, x: torch.Tensor):
+        """
+        Forward pass for RMSNorm.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Normalized tensor with the same shape as input.
+        """
+        return F.rms_norm(x, (self.dim,), self.weight, self.eps)
+
+def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    """
+    Applies rotary positional embeddings to the input tensor.
+
+    Args:
+        x (torch.Tensor): Input tensor with positional embeddings to be applied.
+        freqs_cis (torch.Tensor): Precomputed complex exponential values for positional embeddings.
+
+    Returns:
+        torch.Tensor: Tensor with rotary embeddings applied.
+    """
+    dtype = x.dtype
+    x = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))
+    freqs_cis = freqs_cis.view(1, x.size(1), 1, x.size(-1))
+    y = torch.view_as_real(x * freqs_cis).flatten(3)
+    return y.to(dtype)
+
+def precompute_freqs_cis(args: Args) -> torch.Tensor:
+    """
+    Precomputes frequency-based complex exponential values for rotary positional embeddings.
+
+    Args:
+        args (ModelArgs): Model arguments containing positional embedding parameters.
+
+    Returns:
+        torch.Tensor: Precomputed complex exponential values for positional embeddings.
+    """
+    dim = args.qk_rope_dim
+    seqlen = args.seq_length
+    beta_fast = 32
+    beta_slow = 1
+    base = 10000.0
+    factor = 40
+
+    def find_correction_dim(num_rotations, dim, base, max_seq_len):
+        """
+        Computes the correction dimension for a given number of rotations in the rotary positional embedding.
+
+        Args:
+            num_rotations (float): Number of rotations to compute the correction for.
+            dim (int): Dimensionality of the embedding space.
+            base (float): Base value for the exponential computation.
+            max_seq_len (int): Maximum sequence length.
+
+        Returns:
+            float: The correction dimension based on the input parameters.
+        """
+        return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+    def find_correction_range(low_rot, high_rot, dim, base, max_seq_len):
+        """
+        Computes the range of correction dimensions for rotary positional embeddings.
+
+        Args:
+            low_rot (float): Lower bound for the number of rotations.
+            high_rot (float): Upper bound for the number of rotations.
+            dim (int): Dimensionality of the embedding space.
+            base (float): Base value for the exponential computation.
+            max_seq_len (int): Maximum sequence length.
+
+        Returns:
+            Tuple[int, int]: The range of correction dimensions (low, high), clamped to valid indices.
+        """
+        low = math.floor(find_correction_dim(low_rot, dim, base, max_seq_len))
+        high = math.ceil(find_correction_dim(high_rot, dim, base, max_seq_len))
+        return max(low, 0), min(high, dim-1)
+
+    def linear_ramp_factor(min, max, dim):
+        """
+        Computes a linear ramp function used to smooth values between a minimum and maximum range.
+
+        Args:
+            min (float): Minimum value for the ramp function.
+            max (float): Maximum value for the ramp function.
+            dim (int): Dimensionality of the ramp tensor.
+
+        Returns:
+            torch.Tensor: A tensor of shape (dim,) with values linearly interpolated between 0 and 1,
+                clamped to the range [0, 1].
+        """
+        if min == max:
+            max += 0.001
+        linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+        ramp_func = torch.clamp(linear_func, 0, 1)
+        return ramp_func
+
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    if seqlen > 4096:
+        low, high = find_correction_range(beta_fast, beta_slow, dim, base, 4096)
+        smooth = 1 - linear_ramp_factor(low, high, dim // 2)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    t = torch.arange(seqlen)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    return freqs_cis
+
+#############################
+# End of copy from DeepSeek #
+#############################
+class DeepSeekMLA(torch.nn.Module):
+    """DeepSeekMLA layer for AIOB
+
+    Args:
+        torch (torch.Tensor): input tensor
+
+    forward() return timing in format of dict,
+    i.e.
+        layer_time_map = {
+            "attention_linear_q_lora": q_lora_time,
+            "attention_q_column": q_time,
+            "attention_linear_kv_lora": kv_lora_time,
+            "attention_kv_column": kv_time,
+            "attention_o_row": o_time
+        }
+    # FIXME: create a generic/structured way to return timings
+    # FIXME: fix apply_pe functions, right now they're commented out, should be trivial compute overhead 
+    """
+    def __init__(self, args: Args):
+        super().__init__()
+        self.register_buffer("freqs_cis", precompute_freqs_cis(args), persistent=False)
+        self.args = args
+        self.enable_sequence_parallel = args.enable_sequence_parallel
+        self.tp = args.tensor_model_parallel_size
+        self.qk_head_dim = self.args.qk_nope_dim + self.args.qk_rope_dim
+        # init torch
+        self.device = torch.cuda.current_device()
+        self.dtype = torch.bfloat16
+        self.hidden_size = self.args.hidden_size
+        self.n_local_heads = self.args.num_attention_heads // self.tp
+
+
+        # Q down projection
+        self.wq_a = Linear(self.args.hidden_size, self.args.q_lora_rank, dtype=self.dtype)
+        self.q_norm = RMSNorm(self.args.q_lora_rank, dtype=self.dtype)
+
+        self.wq_b = ColumnParallelLinear(
+            self.args.q_lora_rank, self.args.num_attention_heads * self.qk_head_dim,
+            dtype=self.dtype,
+            world_size=self.tp
+        )
+
+        # # KV down projection
+        self.wkv_a = Linear(
+            self.args.hidden_size, self.args.kv_lora_rank + self.args.qk_rope_dim, dtype=self.dtype
+        )
+
+        self.kv_norm = RMSNorm(self.args.kv_lora_rank, dtype=self.dtype)
+        self.wkv_b = ColumnParallelLinear(
+            self.args.kv_lora_rank,
+            self.args.num_attention_heads
+            * (self.args.qk_nope_dim + self.args.v_head_dim),
+            dtype=self.dtype,
+            world_size=self.tp
+        )
+
+        self.wo = RowParallelLinear(
+            self.args.num_attention_heads * self.args.v_head_dim, self.args.hidden_size,
+            dtype=self.dtype,
+            world_size=self.tp
+        )
+
+        self.softmax_scale = self.qk_head_dim**-0.5
+
+    @cuda_timing_decorator
+    def _apply_linear_q_lora(self, x):
+        return self.q_norm(self.wq_a(x))
+
+    @cuda_timing_decorator
+    def _apply_q(self, x):
+        bsz, seqlen, _ = x.size()
+        q = self.wq_b(x)
+        q = q.view(bsz, seqlen, self.n_local_heads, self.qk_head_dim)
+        q_nope, q_pe = torch.split(q, [self.args.qk_nope_dim, self.args.qk_rope_dim], dim=-1)
+        # q_pe = apply_rotary_emb(q_pe, self.freqs_cis)
+        return (q_nope, q_pe)
+
+    @cuda_timing_decorator
+    def _apply_linear_kv_lora(self, x):
+        kv = self.wkv_a(x)
+        kv, k_pe = torch.split(kv, [self.args.kv_lora_rank, self.args.qk_rope_dim], dim=-1)
+        kv = self.kv_norm(kv)
+        return (kv, k_pe)
+
+    @cuda_timing_decorator
+    def _apply_kv(self, x, q_nope, q_pe, kv, k_pe):
+
+        # k_pe = apply_rotary_emb(k_pe.unsqueeze(2), freqs_cis)
+        k_pe.unsqueeze(2)
+
+        wkv_b = self.wkv_b.weight
+        wkv_b = wkv_b.view(self.n_local_heads, -1, self.args.kv_lora_rank)
+
+        q_nope = torch.einsum("bshd,hdc->bshc", q_nope, wkv_b[:, :self.args.qk_nope_dim])
+
+        scores = (torch.einsum("bshc,btc->bsht", q_nope, kv) +
+                      torch.einsum("bshr,btr->bsht", q_pe, k_pe.squeeze(2))) * self.softmax_scale
+
+        scores = scores.softmax(dim=-1, dtype=torch.float32).type_as(x)
+        x = torch.einsum("bsht,btc->bshc", scores, kv)
+        x = torch.einsum("bshc,hdc->bshd", x, wkv_b[:, -self.args.v_head_dim:])
+        return x
+
+    @cuda_timing_decorator
+    def _apply_kv_naive(self, x, q_nope, q_pe):
+        bsz, seqlen, _ = x.size()
+        # compress kv
+        kv = self.wkv_a(x)
+        kv, k_pe = torch.split(kv, [self.args.kv_lora_rank, self.args.qk_rope_dim], dim=-1)
+        # rotate
+        # k_pe = apply_rotary_emb(k_pe.unsqueeze(2), self.freqs_cis)
+        k_pe = k_pe.unsqueeze(2)
+
+        q = torch.cat([q_nope, q_pe], dim=-1)
+        kv = self.wkv_b(self.kv_norm(kv))
+        kv = kv.view(bsz, seqlen, self.n_local_heads, self.args.qk_nope_dim + self.args.v_head_dim)
+        k_nope, v = torch.split(kv, [self.args.qk_nope_dim, self.args.v_head_dim], dim=-1)
+
+        print(f"kv {kv.shape} k_pe: {k_pe.shape}")
+        k = torch.cat([k_nope, k_pe.expand(-1, -1, self.n_local_heads, -1)], dim=-1)
+        scores = torch.einsum("bshd,bthd->bsht", q, k) * self.softmax_scale
+        scores = scores.softmax(dim=-1, dtype=torch.float32).type_as(x)
+        x = torch.einsum("bsht,bthd->bshd", scores, v)
+        return x
+
+    @cuda_timing_decorator
+    def _apply_wo(self, x):
+        x = self.wo(x.flatten(2))
+        return x
+
+    def forward(self, x):
+        q, q_lora_time = self._apply_linear_q_lora(x)
+        (q_nope, q_pe), q_time = self._apply_q(q)
+        (kv, k_pe), kv_lora_time = self._apply_linear_kv_lora(x)
+        x, kv_time = self._apply_kv(x, q_nope, q_pe, kv, k_pe)
+        x, o_time = self._apply_wo(x)
+        layer_time_map = {
+            "attention_linear_q_lora": q_lora_time,
+            "attention_q_column": q_time,
+            "attention_linear_kv_lora": kv_lora_time,
+            "attention_kv_column": kv_time,
+            "attention_o_row": o_time
+        }
+        return x, layer_time_map
+
+def test_deepseek_mla() -> torch.Tensor:
+    x = torch.randn(5120, 1, 12288, dtype=torch.bfloat16)
+    args = Args(
+        expert_model_parallel_size=1,
+        ffn_hidden_size=4096,
+        hidden_size=12288,
+        num_experts=8,
+        micro_batch=1,
+        moe_router_topk=4,
+        n_shared_expert=2,
+        seq_length=5120,
+        enable_sequence_parallel=True,
+        kv_lora_rank=512,
+        num_attention_heads= 128,
+        q_lora_rank=1536,
+        qk_nope_dim=128,
+        qk_rope_dim=64,
+        tensor_model_parallel_size=1,
+        v_head_dim=128
+    )
+    model = DeepSeekMLA(args)
+    y = model(x)
+    return y
 
 class DeepSeekExpert(torch.nn.Module):
     """DeepSeekExpert"""
@@ -131,7 +680,9 @@ class DeepSeekExpert(torch.nn.Module):
             dtype=torch.bfloat16,
         )
         self.out = torch.empty(
-            (args.seq_length, self.hidden_size), device=self.dev, dtype=torch.bfloat16,
+            (args.seq_length, self.hidden_size),
+            device=self.dev,
+            dtype=torch.bfloat16,
         )
 
     @cuda_timing_decorator
@@ -167,7 +718,9 @@ class DeepSeekMoE(torch.nn.Module):
 
     def __init__(self, args: Args):
         super().__init__()
-        self.n_local_experts = args.n_shared_expert + args.num_experts // args.expert_model_parallel_size
+        self.n_local_experts = (
+            args.n_shared_expert + args.num_experts // args.expert_model_parallel_size
+        )
         self.hidden_size = args.hidden_size
         self.dev = torch.cuda.current_device()
         in_dim = self.hidden_size * args.micro_batch
@@ -182,11 +735,13 @@ class DeepSeekMoE(torch.nn.Module):
         self.topk = topk
         hidden_size = args.hidden_size
         self.dispatched_input = torch.rand(
-            int(seq_len * micro_batch * topk * ep / num_experts * self.n_local_experts),
+            int(seq_len * micro_batch * topk * ep /
+                num_experts * self.n_local_experts),
             hidden_size,
             device=self.dev,
         ).to(torch.bfloat16)
-        self.dispatched_input_fp8 = per_token_cast_to_fp8(self.dispatched_input)
+        self.dispatched_input_fp8 = per_token_cast_to_fp8(
+            self.dispatched_input)
 
         self.tokens_per_expert = torch.full(
             (self.n_local_experts,),
@@ -197,10 +752,13 @@ class DeepSeekMoE(torch.nn.Module):
         for _ in range(self.n_local_experts):
             self.local_experts.append(DeepSeekExpert(args))
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, int,int,int]:
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, int, int, int]:
         mlp_l1_all, mlp_act_all, mlp_l2_all = 0, 0, 0
         o = torch.zeros(
-            self.n_local_experts, x.shape[0], self.hidden_size, device=self.dev,
+            self.n_local_experts,
+            x.shape[0],
+            self.hidden_size,
+            device=self.dev,
         ).to(torch.bfloat16)
         for i, expert in enumerate(self.local_experts):
             out, mlp_l1, mlp_act, mlp_l2 = expert(x.view(-1, self.in_dim))
@@ -223,6 +781,14 @@ def test_deepseek_expert() -> torch.Tensor:
         moe_router_topk=4,
         n_shared_expert=2,
         seq_length=2048,
+        enable_sequence_parallel=True,
+        kv_lora_rank=512,
+        num_attention_heads= 128 + 64,
+        q_lora_rank=0,
+        qk_nope_dim=128,
+        qk_rope_dim=64,
+        tensor_model_parallel_size=1,
+        v_head_dim=128
     )
     model = DeepSeekExpert(args)
     y = model(x)
@@ -240,6 +806,14 @@ def test_deepseek_mlp():
         moe_router_topk=4,
         n_shared_expert=2,
         seq_length=2048,
+        enable_sequence_parallel=True,
+        kv_lora_rank=512,
+        num_attention_heads= 128 + 64,
+        q_lora_rank=16,
+        qk_nope_dim=128,
+        qk_rope_dim=64,
+        tensor_model_parallel_size=1,
+        v_head_dim=128
     )
     model = DeepSeekMoE(args)
     y = model(x)
@@ -247,7 +821,9 @@ def test_deepseek_mlp():
 
 
 def test_expert(
-    m: int = 2048 * 32, n: int = 1024, k: int = 2048 * 32,
+    m: int = 2048 * 32,
+    n: int = 1024,
+    k: int = 2048 * 32,
 ) -> tuple[int, int]:
     """Test DeepSeek's expert MLP.
 
@@ -284,7 +860,7 @@ def do_deepgemm(
     o: torch.Tensor,
     o2: torch.Tensor,
     out: torch.Tensor,
-) -> tuple[int,int]:
+) -> tuple[int, int]:
     deep_gemm.gemm_fp8_fp8_bf16_nt(x, w, o)
     deep_gemm.gemm_fp8_fp8_bf16_nt(x, w2, o2)
     o2 = F.silu(o) + o2
@@ -304,8 +880,11 @@ def do_matmul(
     torch.matmul(x, w.t(), out=o)
     return torch.matmul(F.silu(o), w3, out=out)
 
+device = torch.device("cuda:0")
+torch.set_default_device(device)
 
 if __name__ == "__main__":
+    # torch.set_default_dtype(torch.bfloat16)
     device = torch.device("cuda:0")
     torch.set_default_device(device)
     torch.cuda.set_device(device)
@@ -315,6 +894,7 @@ if __name__ == "__main__":
     # run once to load/cache kernels
     test_deepseek_mlp()
     test_expert()
+    test_deepseek_mla()
 
     # for kineto traces
     import torch.profiler
@@ -327,3 +907,11 @@ if __name__ == "__main__":
         test_deepseek_mlp()
         t0, t1 = test_expert()
     print(f"matmul: deepgemm: {t0} matmul: {t1} diff: {t1 - t0}")
+
+    with torch.profiler.profile(
+        on_trace_ready=torch.profiler.tensorboard_trace_handler("./log"),
+        record_shapes=True,
+        with_flops=True,
+    ) as prof:
+        _, t = test_deepseek_mla()
+    print(f"test_deepseek_mla: compute time {t}")

--- a/workload_generator/mocked_model/AiobMegatron.py
+++ b/workload_generator/mocked_model/AiobMegatron.py
@@ -38,6 +38,7 @@ except ImportError:
     except ImportError:
         flash_attn_unpadded_func = None
 
+from workload_generator.mocked_model.AiobDeepSeek import DeepSeekMoE
 
 class MegatronModel(torch.nn.Module):
     def __init__(self, args=None):
@@ -52,7 +53,10 @@ class MegatronModel(torch.nn.Module):
         else:
             self.Attention = MegatronAtten(self.args)
         if self.args.moe_enable:
-            self.Mlp = MoELayer(self.args)
+            if self.args.frame == "DeepSeek":
+                self.Mlp = DeepSeekMoE(self.args)
+            else:
+                self.Mlp = MoELayer(self.args)
         else:
             self.Mlp = MegatronMlp(self.args)
         self.logit = logit(self.args)
@@ -127,6 +131,7 @@ class MegatronModel(torch.nn.Module):
             self.time_list.setdefault("layernorm_post", []).append(
                 {"time_gpu": layernorm_post}
             )
+            print(f"lay_post__out.shape: {lay_post__out.shape}")
             logit_out, logit_time = self.logit(lay_post__out)
             self.time_list.setdefault("logit_time", []).append({"time_gpu": logit_time})
             _, param_time = self.grad_param._apply()

--- a/workload_generator/mocked_model/MockedDeepSeek.py
+++ b/workload_generator/mocked_model/MockedDeepSeek.py
@@ -1,0 +1,573 @@
+"""
+Provides DeepSeek implementation for MockedModel
+
+Based on https://github.com/deepseek-ai/DeepSeek-V3/tree/f6e34dd26772dd4a216be94a8899276c5dca9e43
+
+@misc{deepseekai2024deepseekv3technicalreport,
+      title={DeepSeek-V3 Technical Report},
+      author={DeepSeek-AI},
+      year={2024},
+      eprint={2412.19437},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2412.19437},
+}
+
+
+File: MockedDeepSeek.py
+License: Apache 2.0
+"""
+
+from workload_generator.mocked_model.MockedModel import MockedModel
+from workload_generator.mocked_model.MockedMegatron import *
+from utils.utils import CommGroup, CommType
+
+
+class DeepSeekLinear(MockedModel):
+    """
+    non-sharded Linear for DeepSeek
+
+    Attributes:
+        in_feature (int): input dimention
+        out_feature (int): output dimention
+        computation_enable (bool): if True, add compute LogItem
+        name (str): layer name
+        bias (bool): if ture, add bias term. Defaults to False
+        // maybe don't need these
+        seq_len (int):
+        batch_size (int):
+    """
+
+    def __init__(
+        self,
+        in_feature: int,
+        out_feature: int,
+        computation_enable: bool,
+        seq_len: int,
+        batch_size: int,
+        layer_id: int,
+        name: str = "",
+        bias: bool = False,
+    ):
+        super().__init__()
+        self.in_feature = in_feature
+        self.out_feature = out_feature
+        self.name = name
+        self.seq_len = seq_len
+        self.batch_size = batch_size
+        self.layer_id = layer_id
+        self.w = MockedParam(
+            (self.in_feature, self.out_feature), name=self.name + "_linear"
+        )
+        if bias:
+            self.bias = MockedParam((out_feature, 1), name=self.name + "_bias")
+        self.computation_enable = computation_enable
+
+    def forward(self):
+        workloads = Workload()
+        if self.computation_enable:
+            workloads.append(
+                LogItem(
+                    comm_type=CommType.computation,
+                    msg_size=(
+                        (self.seq_len, self.batch_size, self.in_feature),
+                        (self.in_feature, self.out_feature),
+                    ),
+                    stage=f"forward.Linear.{self.name}",
+                )
+            )
+        return workloads
+
+    def backward(self):
+        workloads = Workload()
+        if self.computation_enable:
+            workloads.append(
+                LogItem(
+                    comm_type=CommType.computation,
+                    msg_size=(
+                        (self.out_feature, self.seq_len * self.batch_size),
+                        (self.seq_len * self.batch_size, self.in_feature),
+                    ),
+                    stage=f"backward.Linear.{self.name}",
+                )
+            )
+        return workloads
+
+
+class DeepSeekMLA(MockedModel):
+    """Multi Latent Attentnion layer for DeepSeek"""
+
+    def __init__(
+        self,
+        num_attention_heads,
+        hidden_size,
+        tp,
+        seq_len,
+        batch_size,
+        layer_id,
+        sequence_parallel_enabled,
+        computation_enable,
+        add_bias_linear,
+        qk_rope_dim,
+        qk_nope_dim,
+        v_head_dim,
+        q_lora_rank,
+        kv_lora_rank,
+    ):
+        self.name = "attention_layer_mla"
+        self.layer_id = layer_id
+        self.qk_dim = qk_nope_dim + qk_rope_dim
+        self.v_head_dim = v_head_dim
+
+        self.kv_channels = hidden_size // num_attention_heads
+        self.kv_projection_size = self.kv_channels * num_attention_heads
+        self.query_projection_size = self.kv_channels * num_attention_heads
+
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+
+        # Q down projection
+        self.wq_a = DeepSeekLinear(
+            in_feature=hidden_size,
+            out_feature=self.q_lora_rank,
+            computation_enable=computation_enable,
+            name="attention_linear_q_lora",
+            bias=add_bias_linear,
+            layer_id=layer_id,
+            batch_size=batch_size,
+            seq_len=seq_len,
+        )
+        self.q_norm = FusedLayernorm(self.q_lora_rank)
+        self.wq_b = MegatronColumnLinear(
+            self.q_lora_rank,
+            (num_attention_heads) * self.qk_dim,
+            tp,
+            seq_len,
+            batch_size,
+            layer_id,
+            "attention",
+            sequence_parallel_enabled,
+            computation_enable,
+            name="attention_column",
+            add_bias_linear=add_bias_linear,
+        )
+
+        # KV down projection
+        self.wkv_a = DeepSeekLinear(
+            in_feature=hidden_size,
+            out_feature=self.kv_lora_rank + qk_rope_dim,
+            computation_enable=computation_enable,
+            name="attention_linear_kv_lora",
+            bias=add_bias_linear,
+            layer_id=layer_id,
+            batch_size=batch_size,
+            seq_len=seq_len,
+        )
+        self.kv_norm = FusedLayernorm(self.kv_lora_rank)
+        self.wkv_b = MegatronColumnLinear(
+            self.kv_lora_rank,
+            num_attention_heads * (qk_nope_dim + self.v_head_dim),
+            tp,
+            seq_len,
+            batch_size,
+            layer_id,
+            "attention",
+            sequence_parallel_enabled,
+            computation_enable,
+            name="attention_column",
+            add_bias_linear=add_bias_linear,
+        )
+        self.wo = MegatronRowLinear(
+            num_attention_heads * self.v_head_dim,
+            hidden_size,
+            tp,
+            seq_len,
+            batch_size,
+            layer_id,
+            "attention",
+            sequence_parallel_enabled,
+            computation_enable,
+            name="attention_row",
+            add_bias_linear=add_bias_linear,
+        )
+
+    def forward(self):
+        workloads = Workload()
+        # extend for Linear parts
+
+        # for down projected Q
+        # from deepseek.py: https://github.com/deepseek-ai/DeepSeek-V3/blob/f6e34dd26772dd4a216be94a8899276c5dca9e43/inference/model.py#L461C1-L461C53
+        # q = self.wq_b(self.q_norm(self.wq_a(x)))
+        workloads.extend(self.wq_a.forward())
+        # since we don't have a forward() impl for norm, thus skip norm
+        # workloads.extend(self.q_norm.forward())
+
+        workloads.extend(self.wq_b.forward())
+        # add RoPE (ommited here)
+
+        # for down projected KV
+        workloads.extend(self.wkv_a.forward())
+        # similarly for kv_norm, we skip norm because no forward() impl for norm
+        # workloads.extend(self.kv_norm.forward())
+        workloads.extend(self.wkv_b.forward())
+
+        # for O
+        workloads.extend(self.wo.forward())
+        assert all([isinstance(workload, LogItem) for workload in workloads.workload])
+        return workloads
+
+    def backward(self):
+        workloads = Workload()
+        # similar to fwd but .backward()
+        workloads.extend(self.wq_a.backward())
+        workloads.extend(self.wq_b.backward())
+        workloads.extend(self.wkv_a.backward())
+        workloads.extend(self.wkv_b.backward())
+        workloads.extend(self.wo.backward())
+        assert all([isinstance(workload, LogItem) for workload in workloads.workload])
+        return workloads
+
+
+class DeepSeekMoE(MockedModel):
+    def __init__(
+        self,
+        batch_size,
+        hidden_size,
+        tp,
+        expert_model_parallel_size,
+        ffn_hidden_size,
+        seq_len,
+        topk,
+        num_experts,
+        id,
+        n_shared_expert,
+        sequence_parallel_enabled,
+        computation_enable,
+        add_bias_linear,
+    ):
+        self.name = "mlp_moelayer"
+        self.layer_id = id
+        self.name = "mlp_moelayer"
+        self.layer_id = id
+        num_local_experts = num_experts // expert_model_parallel_size
+        fc1_output_size = ffn_hidden_size * num_local_experts
+        fc1_output_size_per_parttition = divide(fc1_output_size, tp)
+        fc2_input_size = ffn_hidden_size * num_local_experts
+        fc2_input_size_per_parttition = divide(fc2_input_size, tp)
+        self.weight1 = MockedParam((hidden_size, fc1_output_size_per_parttition))
+        self.weight2 = MockedParam((fc2_input_size_per_parttition, hidden_size))
+        self.weight3 = MockedParam((hidden_size, fc2_input_size_per_parttition))
+        self.tp_size = tp
+        self.topk = topk
+        self.seq_len = seq_len
+        self.num_experts = num_experts
+        self.batch_size = batch_size
+        self.hidden_size = hidden_size
+        self.shared_experts = None
+        if n_shared_expert > 0:
+            self.shared_experts = MegatronMlp(
+                hidden_size,
+                ffn_hidden_size,
+                tp,
+                seq_len,
+                batch_size,
+                id,
+                sequence_parallel_enabled,
+                computation_enable,
+                add_bias_linear,
+            )
+
+    def permutation(self, stage):
+        workloads = Workload()
+        # FP8 dispatch, include input/128 matrix for scale
+        if self.tp_size > 1:
+            workloads.append(
+                LogItem(
+                    comm_type=CommType.all_to_all,
+                    comm_group=CommGroup.tp_group,
+                    comm_group_size=self.tp_size,
+                    msg_size=(
+                        self.seq_len
+                        * self.hidden_size
+                        * self.batch_size
+                        // self.tp_size
+                    )
+                    + (
+                        self.seq_len
+                        * self.hidden_size
+                        * self.batch_size
+                        // self.tp_size
+                        // 128
+                    ),
+                    stage=f"{stage}.MoE",
+                )
+            )
+        # FP8 dispatch
+        workloads.append(
+            LogItem(
+                comm_type=CommType.all_to_all,
+                comm_group=CommGroup.ep_group,
+                msg_size=(
+                    self.seq_len * self.hidden_size * self.batch_size // self.tp_size
+                )
+                + (
+                    self.seq_len
+                    * self.hidden_size
+                    * self.batch_size
+                    // self.tp_size
+                    // 128
+                ),
+                stage=f"{stage}.MoE",
+            )
+        )
+        if self.tp_size > 1:
+            workloads.append(
+                LogItem(
+                    comm_type=CommType.all_gather,
+                    comm_group=CommGroup.tp_group,
+                    msg_size=(
+                        self.hidden_size * self.topk * self.batch_size * self.seq_len
+                    )
+                    + (
+                        self.hidden_size
+                        * self.topk
+                        * self.batch_size
+                        * self.seq_len
+                        // 128
+                    ),
+                    stage=f"{stage}.MoE.permutation",
+                )
+            )
+
+        return workloads
+
+    def unpermutation(self, stage):
+        workloads = Workload()
+        if self.tp_size > 1:
+            # TODO:we assume tokens consistent split to all experts, but actually its not
+            workloads.append(
+                LogItem(
+                    comm_type=CommType.reduce_scatter,
+                    comm_group=CommGroup.tp_group,
+                    msg_size=2
+                    * self.hidden_size
+                    * self.batch_size
+                    * self.topk
+                    * self.seq_len,
+                    stage=f"{stage}.MoE.unpermutation",
+                )
+            )
+        # bf16 all-to-all combine
+        workloads.append(
+            LogItem(
+                comm_type=CommType.all_to_all,
+                comm_group=CommGroup.ep_group,
+                msg_size=self.seq_len
+                * self.hidden_size
+                * self.batch_size
+                * self.topk
+                // self.tp_size
+                * 2,
+                stage=f"{stage}.MoE",
+            )
+        )
+
+        if self.tp_size > 1:
+            workloads.append(
+                LogItem(
+                    comm_type=CommType.all_to_all,
+                    comm_group=CommGroup.tp_group,
+                    msg_size=2
+                    * self.hidden_size
+                    * self.seq_len
+                    * self.batch_size
+                    // self.tp_size,
+                    stage=f"{stage}.MoE",
+                )
+            )
+
+        return workloads
+
+    def moe_mlp_forward(self):
+        workloads = Workload()
+        workloads.extend(self.permutation(stage="forward"))
+        workloads.extend(self.unpermutation(stage="forward"))
+        assert all([isinstance(workload, LogItem) for workload in workloads.workload])
+        return workloads
+
+    def moe_mlp_backward(self):
+        workloads = Workload()
+        self.permutation(stage="backward")
+        self.unpermutation(stage="backward")
+        assert all([isinstance(workload, LogItem) for workload in workloads.workload])
+        return workloads
+
+    def forward(self):
+        wl = Workload()
+        wl.extend(self.moe_mlp_forward())
+        if self.shared_experts != None:
+            wl.extend(self.shared_experts.forward())
+        return wl
+
+    def backward(self):
+        wl = Workload()
+        if self.shared_experts != None:
+            wl.extend(self.shared_experts.backward())
+        wl.extend(self.moe_mlp_backward())
+        return wl
+
+
+class DeepSeekTransformer(MockedModel):
+    def __init__(
+        self,
+        num_attention_heads,
+        hidden_size,
+        tp,
+        seq_len,
+        batch_size,
+        layer_id,
+        sequence_parallel_enabled,
+        computation_enable,
+        add_bias_linear,
+        qk_rope_dim,
+        qk_nope_dim,
+        v_head_dim,
+        expert_model_parallel_size,
+        ffn_hidden_size,
+        moe_router_topk,
+        num_experts,
+        n_shared_expert,
+        q_lora_rank,
+        kv_lora_rank,
+        use_dense,
+    ):
+        self.attention = DeepSeekMLA(
+            num_attention_heads,
+            hidden_size,
+            tp,
+            seq_len,
+            batch_size,
+            layer_id,
+            sequence_parallel_enabled,
+            computation_enable,
+            add_bias_linear,
+            qk_rope_dim,
+            qk_nope_dim,
+            v_head_dim,
+            q_lora_rank,
+            kv_lora_rank,
+        )
+        self.pre_mlp_layernorm = FusedLayernorm(hidden_size)
+        self.post_attention_layernorm_bias = MockedParam((hidden_size, 1))
+        if use_dense:
+            self.mlp = MegatronMlp(
+                hidden_size,
+                ffn_hidden_size,
+                tp,
+                seq_len,
+                batch_size,
+                layer_id,
+                sequence_parallel_enabled,
+                computation_enable,
+                add_bias_linear,
+            )
+        else:
+            self.mlp = DeepSeekMoE(
+                batch_size,
+                hidden_size,
+                tp,
+                expert_model_parallel_size,
+                ffn_hidden_size,
+                seq_len,
+                moe_router_topk,
+                num_experts,
+                layer_id,
+                n_shared_expert,
+                sequence_parallel_enabled,
+                computation_enable,
+                add_bias_linear,
+            )
+
+    def forward(self):
+        worklods = Workload()
+        worklods.extend(self.attention.forward())
+        worklods.extend(self.mlp.forward())
+        return worklods
+
+    def backward(self):
+        workloads = Workload()
+        workloads.extend(self.attention.backward())
+        workloads.extend(self.mlp.backward())
+        return workloads
+
+
+class DeepSeekV3Model(MockedModel):
+    def __init__(self, config):
+        self.embedding = MegatronEmbedding(
+            config.padded_vocab_size,
+            config.hidden_size,
+            config.tensor_model_parallel_size,
+            config.seq_length,
+            config.micro_batch,
+        )
+        self.layers = [
+            DeepSeekTransformer(
+                num_attention_heads=config.num_attention_heads,
+                hidden_size=config.hidden_size,
+                add_bias_linear=config.add_bias_linear,
+                batch_size=config.micro_batch,
+                computation_enable=config.computation_enable,
+                expert_model_parallel_size=config.expert_model_parallel_size,
+                ffn_hidden_size=config.ffn_hidden_size,
+                layer_id=id,
+                moe_router_topk=config.moe_router_topk,
+                n_shared_expert=config.n_shared_expert,
+                num_experts=config.num_experts,
+                qk_nope_dim=config.qk_nope_dim,  # new
+                qk_rope_dim=config.qk_rope_dim,  # new
+                seq_len=config.seq_length,
+                sequence_parallel_enabled=config.enable_sequence_parallel,
+                tp=config.tensor_model_parallel_size,
+                q_lora_rank=config.q_lora_rank,  # new
+                kv_lora_rank=config.kv_lora_rank,  # new
+                v_head_dim=config.v_head_dim,  # new
+                use_dense=(id < config.n_dense_layers),
+            )
+            for id in range(config.num_layers)
+        ]
+
+        self.final_norm = MegatronColumnLinear(
+            config.hidden_size,
+            config.padded_vocab_size,
+            config.tensor_model_parallel_size,
+            config.seq_length,
+            config.micro_batch,
+            1,
+            "final",
+            sequence_parallel_enabled=config.enable_sequence_parallel,
+            computation_enable=config.computation_enable,
+            add_bias_linear=config.add_bias_linear,
+        )
+
+    def forward(self):
+        workloads = Workload()
+        workloads.extend(self.embedding.forward())
+        for layer in self.layers:
+            fwd = layer.forward()
+            if not isinstance(fwd, Workload):
+                continue
+            workloads.extend(fwd)
+
+        assert all([isinstance(workload, LogItem) for workload in workloads.workload])
+        return workloads
+
+    def backward(self):
+        workloads = Workload()
+        for layer in self.layers[::-1]:
+            bwd = layer.backward()
+            if not isinstance(bwd, Workload):
+                continue
+            workloads.extend(bwd)
+        workloads.extend(self.embedding.backward())
+        assert all([isinstance(workload, LogItem) for workload in workloads.workload])
+        return workloads

--- a/workload_generator/mocked_model/MockedDeepSeek.py
+++ b/workload_generator/mocked_model/MockedDeepSeek.py
@@ -148,10 +148,10 @@ class DeepSeekMLA(MockedModel):
             seq_len,
             batch_size,
             layer_id,
-            "attention",
+            "attention_q",
             sequence_parallel_enabled,
             computation_enable,
-            name="attention_column",
+            name="attention_q_column",
             add_bias_linear=add_bias_linear,
         )
 
@@ -174,10 +174,10 @@ class DeepSeekMLA(MockedModel):
             seq_len,
             batch_size,
             layer_id,
-            "attention",
+            "attention_kv",
             sequence_parallel_enabled,
             computation_enable,
-            name="attention_column",
+            name="attention_kv_column",
             add_bias_linear=add_bias_linear,
         )
         self.wo = MegatronRowLinear(
@@ -187,10 +187,10 @@ class DeepSeekMLA(MockedModel):
             seq_len,
             batch_size,
             layer_id,
-            "attention",
+            "attention_o",
             sequence_parallel_enabled,
             computation_enable,
-            name="attention_row",
+            name="attention_o_row",
             add_bias_linear=add_bias_linear,
         )
 

--- a/workload_generator/mocked_model/MockedDeepSeek.py
+++ b/workload_generator/mocked_model/MockedDeepSeek.py
@@ -311,7 +311,7 @@ class DeepSeekMoE(MockedModel):
                 comm_type=CommType.all_to_all,
                 comm_group=CommGroup.ep_group,
                 msg_size=(
-                    self.seq_len * self.hidden_size * self.batch_size // self.tp_size
+                    self.seq_len * self.hidden_size * self.batch_size * self.topk // self.tp_size
                 )
                 * 2
                 * scaled,
@@ -357,7 +357,7 @@ class DeepSeekMoE(MockedModel):
                 msg_size=self.seq_len
                 * self.hidden_size
                 * self.batch_size
-                * self.expert_model_parallel_size
+                * self.topk
                 // self.tp_size
                 * 2,
                 stage=f"{stage}.MoE",


### PR DESCRIPTION
# What's new?

Adds `MockedModel` for DeepSeek-v3 based on open source model's code[^1], DeepGEMM[^4] and technical report paper[^2]

# Details

## `MockedDeepSeek`

mostly based on `MockedMegatron` for DP, TP comms.

- add `DeepSeekV3Model` top-level module
- add `DeepSeekMoE` for MoE with shared-experts. Comms to use FP8 dispatch and BF16 combine.[^2]
- add `DeepSeekMLA` for Multi-Head Latent Attention (MLA) layer
  - use compression matrix[^2], it's mentioned as LoRA in DeepSeek-v3's `model.py`[^3][^5]
  - decoupled rotary positional embedding (i.e. RoPE)

## `AiobDeepSeek`

modifies `AiobMegatron` to include FP8 matmul kernels from DeepGEMM[^4] to get compute times for experts

**Update 9/12/2025**:  Add `DeepSeekMLA` support in AIOB https://github.com/aliyun/aicb/pull/41/commits/588c201d2c44caf466a94c62398fe2ed867e5929

# Generated Workload

## GPU Workload with AIOB

```bash
sh scripts/megatron_gpt.sh \
  --frame DeepSeek \
  --tensor_model_parallel_size 4 \
  --pipeline_model_parallel 1 \
  --moe_enable \
  --expert_model_parallel_size 1 \
  --global_batch 4 \
  -m deepseek \
  --num_experts 4 \
  --micro_batch 1 \
  --sp --swiglu --world_size 4 --num_layers 10 --aiob_enable
```

Workload CSV file: [megatron_DeepSeek_sp_True_iteration_1_computationEnable_True_4n_log.csv](https://github.com/user-attachments/files/21850121/megatron_DeepSeek_sp_True_iteration_1_computationEnable_True_4n_log.csv)

## SimAI workload with AIOB

In the AIOB timing, note that `mlp_*` times for DeepSeek's MoE is much higher compared to that of Megatron even with FP8, that's mostly because of the extra linear layer in DeepSeek's Expert

i.e.

```python
# DeepSeek's Expert
self.w2(F.silu(self.w1(x)) * self.w3(x))

# vs Megatron's Expert
self.w2(act_fn(self.w1(x))
```

```bash
sh scripts/megatron_workload_with_aiob.sh \
-m deepseek16 --world_size 2048 --tensor_model_parallel_size 1 --pipeline_model_parallel 1 --sp --ep 16 \
--moe_router_topk 6 --moe_enable  \
--frame DeepSeek --global_batch 4096 \
--micro_batch 1 --seq_length 4096 --swiglu \
--aiob_enable
```

SimAI workload: 
[None-DeepSeek_16B-world_size2048-tp1-pp1-ep16-gbs4096-mbs1-seq4096-MOE-True-GEMM-False-flash_attn-False.txt](https://github.com/user-attachments/files/21850156/None-DeepSeek_16B-world_size2048-tp1-pp1-ep16-gbs4096-mbs1-seq4096-MOE-True-GEMM-False-flash_attn-False.txt)

DeepSeek16 AIOB Compute times on H100: 
[DeepSeek_16B-world_size2048-tp1-pp1-ep16-gbs4096-mbs1-seq4096-flash_attn-False.txt](https://github.com/user-attachments/files/21850178/DeepSeek_16B-world_size2048-tp1-pp1-ep16-gbs4096-mbs1-seq4096-flash_attn-False.txt)



# Citations

```
@misc{deepseekai2024deepseekv3technicalreport,
      title={DeepSeek-V3 Technical Report}, 
      author={DeepSeek-AI},
      year={2024},
      eprint={2412.19437},
      archivePrefix={arXiv},
      primaryClass={cs.CL},
      url={https://arxiv.org/abs/2412.19437}, 
}
```

[^1]: https://github.com/deepseek-ai/DeepSeek-V3/tree/f6e34dd26772dd4a216be94a8899276c5dca9e43

[^2]: [DeepSeek-V3 Technical Report](https://arxiv.org/abs/2412.19437)

[^3]: https://github.com/deepseek-ai/DeepSeek-V3/blob/f6e34dd26772dd4a216be94a8899276c5dca9e43/inference/model.py#L42-L43

[^4]: https://github.com/deepseek-ai/DeepGEMM/tree/391755ada0ffefa9a6a52b6f14dcaf22d1a463e0

[^5]: ![deepseek-aicb-mla drawio](https://github.com/user-attachments/assets/149e0d35-386b-4d10-8b8a-537abe030e00)
