### PR TITLE
Update MoE Communication

### DIFF
--- a/workload_generator/AIOB_simAI_workload_generator.py
+++ b/workload_generator/AIOB_simAI_workload_generator.py
@@ -446,7 +446,7 @@ class SIMAI_workload:
                             forward_comm4 = "NONE"
 
                         # if args.expert_model_parallel_size != 1:
-                        ep_allgather_size = self.expert_model_parallel_size * self.num_experts * self.tp
+                        ep_allgather_size = 2 * self.expert_model_parallel_size * self.num_experts * self.tp
                         fwd_ep_dispatch_size = tp_comm_size * self.topk // self.tp
                         bkwd_ep_dispatch_size = tp_comm_size * self.topk // self.tp
                         ep_combine_size = tp_comm_size * self.topk // self.tp
@@ -459,7 +459,7 @@ class SIMAI_workload:
                         # EP All gather
                         self.workload.append(Work_Item(name=name, forward_compute_time=forward_compute_time,
                                     forward_comm = forward_comm1, forward_comm_size=ep_allgather_size,
-                                    backward_compute_time=backward_compute_time, backward_comm=forward_comm1, backward_comm_size=ep_allgather_size,
+                                    backward_compute_time=backward_compute_time, backward_comm="NONE", backward_comm_size=0,
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
                         # EP dispatch
@@ -711,46 +711,49 @@ class SIMAI_workload:
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
                     if "moelayer" in name:
-                        forward_comm1 = "ALLGATHER"
-                        forward_comm2 = "ALLTOALL"
-                        forward_comm3 = "ALLTOALL_EP"
-                        forward_comm4 = "ALLGATHER"
-                        forward_comm5 = "REDUCESCATTER"
-                        forward_comm6 = "ALLTOALL_EP"
-                        forward_comm7 = "ALLTOALL"
+                        forward_comm1 = "ALLGATHER" # for EP
+                        forward_comm2 = "ALLTOALL_EP"
+                        forward_comm3 = "ALLGATHER"
+                        forward_comm4 = "REDUCESCATTER"
+                        forward_comm5 = "ALLTOALL_EP"
+                        # if args.expert_model_parallel_size != 1:
+                        ep_allgather_size = 2 * self.expert_model_parallel_size * self.num_experts * self.tp
+                        fwd_ep_dispatch_size = tp_comm_size * self.topk // self.tp
+                        bkwd_ep_dispatch_size = tp_comm_size * self.topk // self.tp
+                        ep_combine_size = tp_comm_size * self.topk // self.tp
+
+                        if self.args.frame == "DeepSeek":
+                            # for DeepEP based on https://github.com/parthpower/DeepEP/commit/50aee15f592bc22142eb04b7d718296b19613ae9
+                            # only fprop does the FP8
+                            fwd_ep_dispatch_size = int(fwd_ep_dispatch_size * MockedDeepSeek.FP8_FACTOR)
+                            # rest of the comm shapes are similar to megatron
+                        # EP All gather
                         self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm1, forward_comm_size= 2*self.seq_len*self.num_experts,
-                                    backward_compute_time=default_compute_time, backward_comm=forward_comm1, backward_comm_size=2*self.seq_len*self.num_experts,
+                                    forward_comm = forward_comm1, forward_comm_size=ep_allgather_size,
+                                    backward_compute_time=default_compute_time, backward_comm="NONE", backward_comm_size=0,
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
+                        # EP dispatch
                         self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm2, forward_comm_size= tp_comm_size//self.tp,
-                                    backward_compute_time=default_compute_time, backward_comm=forward_comm2, backward_comm_size=tp_comm_size//self.tp,
+                                    forward_comm = forward_comm2, forward_comm_size=fwd_ep_dispatch_size,
+                                    backward_compute_time=default_compute_time, backward_comm=forward_comm2, backward_comm_size=bkwd_ep_dispatch_size,
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
+                        # TP All reduce
                         self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm3, forward_comm_size= tp_comm_size*self.topk//self.tp,
-                                    backward_compute_time=default_compute_time, backward_comm=forward_comm3, backward_comm_size=tp_comm_size*self.topk//self.tp,
-                                    dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
-                                    ))
-                        self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm4, forward_comm_size= tp_comm_size*self.topk//self.tp,
+                                    forward_comm = forward_comm3, forward_comm_size=tp_comm_size*self.topk,
                                     backward_compute_time=default_compute_time, backward_comm=forward_comm4, backward_comm_size=tp_comm_size*self.topk,
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
                         self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm5, forward_comm_size= tp_comm_size*self.topk//self.tp,
-                                    backward_compute_time=default_compute_time, backward_comm=forward_comm4, backward_comm_size=tp_comm_size*self.topk//self.tp,
+                                    forward_comm = forward_comm4, forward_comm_size=tp_comm_size*self.topk,
+                                    backward_compute_time=default_compute_time, backward_comm=forward_comm3, backward_comm_size=tp_comm_size*self.topk,
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
+                        # EP combine
                         self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm6, forward_comm_size= tp_comm_size*self.topk//self.tp,
-                                    backward_compute_time=default_compute_time, backward_comm=forward_comm6, backward_comm_size=tp_comm_size*self.topk//self.tp,
-                                    dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
-                                    ))
-                        self.workload.append(Work_Item(name=name, forward_compute_time=default_compute_time,
-                                    forward_comm = forward_comm7, forward_comm_size= tp_comm_size//self.tp,
-                                    backward_compute_time=default_compute_time, backward_comm=forward_comm7, backward_comm_size=tp_comm_size//self.tp,
+                                    forward_comm = forward_comm5, forward_comm_size=ep_combine_size,
+                                    backward_compute_time=default_compute_time, backward_comm=forward_comm5, backward_comm_size=ep_combine_size,
                                     dp_compute_time=default_compute_time, dp_comm=dp_comm, dp_comm_size=dp_comm_size
                                     ))
                         


### PR DESCRIPTION
This PR refactors the MoE communication simulation, upgrading its behavior from Megatron-LM core_v0.8.0 to core_v0.13.0 （based on https://github.com/NVIDIA/Megatron-LM/tree/core_v0.13.0/megatron/core/transformer/moe). The forward pass now correctly models the following communication sequence:

- EP All-Gather
- EP All-to-All (dispatch)
- TP All-Gather & Reduce-Scatter
- EP All-to-All (combine)

This ensures a more accurate simulation of communication costs in modern MoE architectures.

